### PR TITLE
Enhance Daikin API integration by adding refresh command handling and…

### DIFF
--- a/src/modules/daikin.ts
+++ b/src/modules/daikin.ts
@@ -12,7 +12,7 @@ import {
 } from "./gateway";
 import {makeDefineFile} from "./converter";
 import {publishConfig, publishToMQTT} from "./mqtt";
-import {DaikinCloudController} from "daikin-controller-cloud";
+import {DaikinCloudController, OnectaMockDevice} from "daikin-controller-cloud";
 import {DaikinCloudDevice} from "daikin-controller-cloud/dist/device";
 
 async function loadDaikinAPI() {
@@ -79,6 +79,7 @@ async function loadDaikinAPI() {
 
 async function startDaikinAPI() {
 	const devices = await getDevices();
+	console.log(devices);
 	logger.info("[daikin.ts] => Subscribe to MQTT Action")
 	await subscribeDevices(devices)
 	logger.info("[daikin.ts] => Generate Config Info")
@@ -95,12 +96,28 @@ async function subscribeDevices(devices: DaikinCloudDevice[]) {
 		})
 	}
 
+	// Subscribe to refresh command topic
+	let refreshTopic = config.mqtt.topic + "/system/bridge/refresh/set"
+	mqttClient.subscribe(refreshTopic, function (err) {
+		if (!err) logger.info("[daikin.ts] => Subscribe to " + refreshTopic)
+	})
+
 	mqttClient.on('message', async function (topic, message) {
 		logger.debug(`[daikin.ts] => Topic : ${topic} \n- Message : ${message.toString()}`)
 
+		const topicString = topic.toString();
+		const refreshTopicPath = config.mqtt.topic + "/system/bridge/refresh/set";
+
+		// Handle refresh command
+		if (topicString === refreshTopicPath) {
+			logger.info("[daikin.ts] => Refresh command received, updating all devices")
+			await sendDevice(null, true) // Force refresh from cloud
+			return
+		}
+
 		const devices = await getDevices();
 		for (let dev of devices) {
-			if (!topic.toString().includes(dev.getId())) continue;
+			if (!topicString.includes(dev.getId())) continue;
 			let gateway = getModels(dev);
 			if (gateway !== undefined) {
 				await eventValue(dev, gateway, JSON.parse(message.toString()))


### PR DESCRIPTION
… logging device updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds MQTT refresh command handling to trigger cloud-sourced device updates, with minor logging and topic handling tweaks.
> 
> - **Daikin MQTT Integration**:
>   - **Refresh Command**: Subscribes to `config.mqtt.topic + "/system/bridge/refresh/set"` and, on message, forces a cloud refresh via `sendDevice(null, true)`.
>   - **Message Handling**: Normalizes topic to `topicString` and uses it for device routing; preserves existing per-device `/set` subscriptions.
> - **Logging**:
>   - Logs full device list on startup and adds info/debug logs around refresh handling.
> - **Deps**:
>   - Imports `OnectaMockDevice` from `daikin-controller-cloud` (unused).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4872cd81c044db93d69c8f101ad79a363235e8c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->