### PR TITLE
Feature/day night refresh

### DIFF
--- a/config/settings-default.yml
+++ b/config/settings-default.yml
@@ -2,8 +2,8 @@ system:
   logLevel: 'info' # Indicates the level of log that the system must use
   jeedom: false # Activate the integration for the Jeedom home automation system
   polling:
-    dayInterval: 15 # Intervalle de rafraîchissement en minutes pendant la journée
-    nightInterval: 60 # Intervalle de rafraîchissement en minutes pendant la nuit
+    dayInterval: 10 # Intervalle de rafraîchissement en minutes pendant la journée
+    nightInterval: 20 # Intervalle de rafraîchissement en minutes pendant la nuit
     nightStart: 22 # Heure de début de la période nuit (0-23)
     nightEnd: 7 # Heure de fin de la période nuit (0-23)
 daikin:

--- a/config/settings-default.yml
+++ b/config/settings-default.yml
@@ -1,6 +1,11 @@
 system:
   logLevel: 'info' # Indicates the level of log that the system must use
   jeedom: false # Activate the integration for the Jeedom home automation system
+  polling:
+    dayInterval: 15 # Intervalle de rafraîchissement en minutes pendant la journée
+    nightInterval: 60 # Intervalle de rafraîchissement en minutes pendant la nuit
+    nightStart: 22 # Heure de début de la période nuit (0-23)
+    nightEnd: 7 # Heure de fin de la période nuit (0-23)
 daikin:
   clientID: null # Client ID allowing connection to the Daikin Onecta Cloud
   clientSecret: null # Client Secret allowing connection to the Daikin Onecta cloud

--- a/src/modules/cron.ts
+++ b/src/modules/cron.ts
@@ -1,13 +1,112 @@
 import cron from "node-cron";
 import {sendDevice, timeUpdate} from "./daikin";
 
-async function loadCron() {
-	cron.schedule('0 */15 * * * *', async function () {
-		logger.debug("[cron.ts] => CRON - Daikin Polling = RUN")
-		await sendDevice(null, true)
-		logger.debug("[cron.ts] => CRON - Daikin Polling = FINISH")
-	});
+/**
+ * Détermine si on est actuellement en période nuit
+ */
+function isNightTime(): boolean {
+	const now = new Date();
+	const currentHour = now.getHours();
+	
+	const pollingConfig = config.system.polling;
+	if (!pollingConfig) {
+		// Par défaut, si pas de config, on considère qu'on est en journée
+		return false;
+	}
+	
+	const nightStart = pollingConfig.nightStart ?? 22;
+	const nightEnd = pollingConfig.nightEnd ?? 7;
+	
+	// Gestion du cas où la période nuit traverse minuit (ex: 22h-7h)
+	if (nightStart > nightEnd) {
+		// Période nuit qui traverse minuit (ex: 22h à 7h)
+		return currentHour >= nightStart || currentHour < nightEnd;
+	} else {
+		// Période nuit dans la même journée (ex: 0h à 6h)
+		return currentHour >= nightStart && currentHour < nightEnd;
+	}
+}
 
+/**
+ * Récupère l'intervalle de polling actuel en fonction de l'heure
+ */
+function getCurrentPollingInterval(): number {
+	const pollingConfig = config.system.polling;
+	if (!pollingConfig) {
+		// Par défaut, 15 minutes si pas de config
+		return 15;
+	}
+	
+	return isNightTime() 
+		? (pollingConfig.nightInterval ?? 60)
+		: (pollingConfig.dayInterval ?? 15);
+}
+
+/**
+ * Calcule le temps jusqu'au prochain intervalle en millisecondes
+ */
+function getTimeUntilNextInterval(): number {
+	const intervalMinutes = getCurrentPollingInterval();
+	const now = new Date();
+	const currentMinutes = now.getMinutes();
+	const currentSeconds = now.getSeconds();
+	
+	// Calculer les secondes écoulées dans l'heure actuelle
+	const secondsInCurrentHour = currentMinutes * 60 + currentSeconds;
+	
+	// Calculer le prochain intervalle (en secondes)
+	const intervalSeconds = intervalMinutes * 60;
+	
+	// Calculer le temps jusqu'au prochain intervalle
+	const nextInterval = Math.ceil(secondsInCurrentHour / intervalSeconds) * intervalSeconds;
+	const timeUntilNext = (nextInterval - secondsInCurrentHour) * 1000;
+	
+	return timeUntilNext;
+}
+
+let pollingTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Planifie le prochain polling en fonction de l'heure actuelle
+ */
+function scheduleNextPolling() {
+	// Annuler le timer précédent s'il existe
+	if (pollingTimer) {
+		clearTimeout(pollingTimer);
+	}
+	
+	const timeUntilNext = getTimeUntilNextInterval();
+	const isNight = isNightTime();
+	const interval = getCurrentPollingInterval();
+	
+	logger.debug(`[cron.ts] => Prochain polling dans ${Math.round(timeUntilNext / 1000)}s (${isNight ? 'nuit' : 'jour'} - intervalle: ${interval}min)`);
+	
+	pollingTimer = setTimeout(async () => {
+		logger.debug(`[cron.ts] => CRON - Daikin Polling = RUN (${isNightTime() ? 'nuit' : 'jour'})`);
+		await sendDevice(null, true);
+		logger.debug("[cron.ts] => CRON - Daikin Polling = FINISH");
+		
+		// Planifier le prochain polling
+		scheduleNextPolling();
+	}, timeUntilNext);
+}
+
+async function loadCron() {
+	// Configuration par défaut si non définie
+	if (!config.system.polling) {
+		config.system.polling = {
+			dayInterval: 15,
+			nightInterval: 60,
+			nightStart: 22,
+			nightEnd: 7
+		};
+		logger.warn("[cron.ts] => Configuration polling non trouvée, utilisation des valeurs par défaut");
+	}
+	
+	// Démarrer le polling dynamique
+	scheduleNextPolling();
+	
+	// Garder le cron pour le refresh après action (toutes les 30 secondes)
 	cron.schedule('*/30 * * * * *', async function () {
 		logger.debug("[cron.ts] => CRON - Refresh data after action = RUN")
 		await timeUpdate()

--- a/src/modules/cron.ts
+++ b/src/modules/cron.ts
@@ -33,13 +33,13 @@ function isNightTime(): boolean {
 function getCurrentPollingInterval(): number {
 	const pollingConfig = config.system.polling;
 	if (!pollingConfig) {
-		// Par défaut, 15 minutes si pas de config
-		return 15;
+		// Par défaut, 10 minutes si pas de config
+		return 10;
 	}
 	
 	return isNightTime() 
-		? (pollingConfig.nightInterval ?? 60)
-		: (pollingConfig.dayInterval ?? 15);
+		? (pollingConfig.nightInterval ?? 20)
+		: (pollingConfig.dayInterval ?? 10);
 }
 
 /**
@@ -95,16 +95,37 @@ async function loadCron() {
 	// Configuration par défaut si non définie
 	if (!config.system.polling) {
 		config.system.polling = {
-			dayInterval: 15,
-			nightInterval: 60,
+			dayInterval: 10,
+			nightInterval: 20,
 			nightStart: 22,
 			nightEnd: 7
 		};
 		logger.warn("[cron.ts] => Configuration polling non trouvée, utilisation des valeurs par défaut");
 	}
 	
+	const pollingConfig = config.system.polling;
+	const isNight = isNightTime();
+	const currentInterval = getCurrentPollingInterval();
+	const now = new Date();
+	const currentTime = now.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+	
+	// Log des informations de configuration au démarrage
+	logger.info("[cron.ts] => Configuration du polling dynamique :");
+	logger.info(`[cron.ts] =>   - Intervalle journée : ${pollingConfig.dayInterval} minutes`);
+	logger.info(`[cron.ts] =>   - Intervalle nuit : ${pollingConfig.nightInterval} minutes`);
+	logger.info(`[cron.ts] =>   - Période nuit : ${pollingConfig.nightStart}h - ${pollingConfig.nightEnd}h`);
+	logger.info(`[cron.ts] =>   - Heure actuelle : ${currentTime} (${isNight ? 'nuit' : 'jour'})`);
+	logger.info(`[cron.ts] =>   - Intervalle actuel : ${currentInterval} minutes`);
+	
 	// Démarrer le polling dynamique
 	scheduleNextPolling();
+	
+	// Refresh forcé à 23h58 chaque jour pour les stats électriques
+	cron.schedule('58 23 * * *', async function () {
+		logger.info("[cron.ts] => CRON - Refresh forcé à 23h58 pour les stats électriques = RUN");
+		await sendDevice(null, true);
+		logger.info("[cron.ts] => CRON - Refresh forcé à 23h58 pour les stats électriques = FINISH");
+	});
 	
 	// Garder le cron pour le refresh après action (toutes les 30 secondes)
 	cron.schedule('*/30 * * * * *', async function () {

--- a/src/types/Daikin2MQTT.d.ts
+++ b/src/types/Daikin2MQTT.d.ts
@@ -9,6 +9,14 @@ export interface Daikin2MQTT {
 export interface ConfigSystem {
 	logLevel: string
 	jeedom: boolean
+	polling?: ConfigPolling
+}
+
+export interface ConfigPolling {
+	dayInterval: number // Intervalle en minutes pour le polling en journée
+	nightInterval: number // Intervalle en minutes pour le polling la nuit
+	nightStart: number // Heure de début de la période nuit (0-23)
+	nightEnd: number // Heure de fin de la période nuit (0-23)
 }
 
 export interface ConfigDaikin {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce configurable day/night polling with dynamic scheduling and a daily 23:58 refresh, updating config and types.
> 
> - **Cron / Scheduling**:
>   - Dynamic polling based on day/night via `isNightTime`, `getCurrentPollingInterval`, timed `scheduleNextPolling` (replaces fixed 15-min cron).
>   - Default polling fallback with startup logs; keeps 30s "refresh after action" cron.
>   - Adds daily forced refresh at `23:58`.
> - **Config**:
>   - Introduces `system.polling` in `config/settings-default.yml` with `dayInterval`, `nightInterval`, `nightStart`, `nightEnd`.
> - **Types**:
>   - Adds `ConfigPolling` and optional `system.polling` to `ConfigSystem` in `Daikin2MQTT.d.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 993a5f8b3f40af1182975b6a70478a38e3d4ccc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->