### PR TITLE
Refactor logging and error handling in main and daikin modules; impro…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import { setTimeout } from "timers/promises";
 	global.datadir = process.env.STORE_DIR || process.cwd() + "/config"
 	global.logger = loadLogger()
 
-	console.info("[main.ts] => Starting DaikinToMQTT")
+	logger.info("[main.ts] => Starting DaikinToMQTT")
 	logger.info("[main.ts] => Load configuration")
 	await loadGlobalConfig()
 	logger.info("[main.ts] => Connect to MQTT")
@@ -34,21 +34,21 @@ import { setTimeout } from "timers/promises";
 
 	if (error.error == "invalid_grant") {
 		try {
-			console.log('====> Token invalid, delete de l ancien token, une reconnection va être necesaire')
-			let path = resolve(datadir, 'daikin-controller-cloud-tokenset')
-			fs.unlinkSync(path);
+			logger.error('====> Token invalid, delete de l ancien token, une reconnection va être necesaire')
+			const tokenPath = resolve(datadir, 'daikin-controller-cloud-tokenset')
+			fs.unlinkSync(tokenPath);
 			process.exit(1)
 		} catch (e) {
-			console.error('Merci de delete le fichier : path');
+			logger.error(`Merci de delete le fichier : ${resolve(datadir, 'daikin-controller-cloud-tokenset')}`);
 			process.exit(1)
 		}
 	} else if (error == 'Error: Authorization time out') {
-		console.log('====> Authorization time out, please restart DaikinToMQTT and retry')
+		logger.error('====> Authorization time out, please restart DaikinToMQTT and retry')
 		await publishConfig('authorization_timeout', true);
 		await setTimeout(5000)
 		process.exit(1)
 	} else {
-		console.error(error)
+		logger.error(`[main.ts] => Unhandled error: ${error}`)
 	}
 })
 

--- a/src/modules/daikin.ts
+++ b/src/modules/daikin.ts
@@ -12,7 +12,7 @@ import {
 } from "./gateway";
 import {makeDefineFile} from "./converter";
 import {publishConfig, publishToMQTT} from "./mqtt";
-import {DaikinCloudController} from "daikin-controller-cloud";
+import {DaikinCloudController, OnectaMockDevice} from "daikin-controller-cloud";
 import {DaikinCloudDevice} from "daikin-controller-cloud/dist/device";
 
 async function loadDaikinAPI() {
@@ -40,7 +40,7 @@ async function loadDaikinAPI() {
 		oidcAuthorizationTimeoutS: 120
 	});
 
-	daikinClient.on('authorization_request', (url) => {
+	daikinClient.on('authorization_request', async (url) => {
 		logger.info(`[daikin.ts] =>
 			Please make sure that ${url} is set as "Redirect URL" in your Daikin Developer Portal account for the used Client!
 			 
@@ -48,9 +48,13 @@ async function loadDaikinAPI() {
 			 
 			Afterwards you are redirected to Daikin to approve the access and then redirected back.`);
 
-		publishConfig('url', url).then()
-		publishConfig('authorization_request', true).then()
-		publishConfig('authorization_timeout', false).then()
+		try {
+			await publishConfig('url', url);
+			await publishConfig('authorization_request', true);
+			await publishConfig('authorization_timeout', false);
+		} catch (error) {
+			logger.error(`[daikin.ts] => Error publishing authorization config: ${error}`);
+		}
 	});
 
 	daikinClient.on('rate_limit_status', async (rateLimitStatus) => {
@@ -79,6 +83,11 @@ async function loadDaikinAPI() {
 
 async function startDaikinAPI() {
 	const devices = await getDevices();
+	if (!devices) {
+		logger.error("[daikin.ts] => No devices found, cannot start API");
+		return;
+	}
+	logger.debug(`[daikin.ts] => Found ${devices.length} device(s)`);
 	logger.info("[daikin.ts] => Subscribe to MQTT Action")
 	await subscribeDevices(devices)
 	logger.info("[daikin.ts] => Generate Config Info")
@@ -96,15 +105,33 @@ async function subscribeDevices(devices: DaikinCloudDevice[]) {
 	}
 
 	mqttClient.on('message', async function (topic, message) {
-		logger.debug(`[daikin.ts] => Topic : ${topic} \n- Message : ${message.toString()}`)
+		try {
+			logger.debug(`[daikin.ts] => Topic : ${topic} \n- Message : ${message.toString()}`)
 
-		const devices = await getDevices();
-		for (let dev of devices) {
-			if (!topic.toString().includes(dev.getId())) continue;
-			let gateway = getModels(dev);
-			if (gateway !== undefined) {
-				await eventValue(dev, gateway, JSON.parse(message.toString()))
+			// Utiliser le cache des devices au lieu de les récupérer à chaque fois
+			const cachedDevices = await cache.get('devices') as DaikinCloudDevice[] | undefined;
+			// Vérifier explicitement null/undefined pour distinguer "pas de cache" de "cache avec tableau vide"
+			const devices = (cachedDevices !== undefined && cachedDevices !== null) ? cachedDevices : await getDevices();
+			
+			const topicStr = topic.toString();
+			let parsedMessage: any;
+			
+			try {
+				parsedMessage = JSON.parse(message.toString());
+			} catch (parseError) {
+				logger.error(`[daikin.ts] => Error parsing MQTT message: ${parseError}`);
+				return;
 			}
+
+			for (let dev of devices) {
+				if (!topicStr.includes(dev.getId())) continue;
+				let gateway = getModels(dev);
+				if (gateway !== undefined) {
+					await eventValue(dev, gateway, parsedMessage);
+				}
+			}
+		} catch (error) {
+			logger.error(`[daikin.ts] => Error processing MQTT message: ${error}`);
 		}
 	})
 }
@@ -114,7 +141,9 @@ async function sendDevice(devices: DaikinCloudDevice[] | null = null, cron: bool
 
 	if (devices && devices.length) {
 		for (let dev of devices) {
-			global.cache[dev.getId()] = dev;
+			// Utiliser cache.set() au lieu de l'indexation directe
+			// TTL de 10 minutes pour correspondre au cache de la liste des devices
+			await cache.set(`device_${dev.getId()}`, dev, 600000);
 			let gateway = getModels(dev);
 			await publishToMQTT(dev.getId(), JSON.stringify(gateway))
 		}
@@ -128,7 +157,7 @@ async function timeUpdate() {
 	let timerefresh = await cache.get('needRefresh')
 	logger.debug("[daikin.ts] => Timestamp Save : " + timerefresh)
 	if (timerefresh == undefined) return;
-	if (typeof(timerefresh) != "number") {
+	if (typeof timerefresh !== "number") {
 		await cache.del('needRefresh');
 		return;
 	}
@@ -178,17 +207,26 @@ async function generateConfig(devices: DaikinCloudDevice[]) {
 }
 
 async function getDevices(force: boolean = false) {
-	const devices = await cache.get('devices')
+	const devices = await cache.get('devices') as DaikinCloudDevice[] | undefined;
 	if (devices == undefined || force)  {
 		logger.debug("[daikin.ts] => Cache invalid ou recup forcé, recuperation information sur le cloud")
 		logger.debug('[daikin.ts] => Send Request to cloud : Refresh')
-		const devices = await daikinClient.getCloudDevices();
-		await cache.set('devices', devices);
-		return devices
+		const freshDevices = await daikinClient.getCloudDevices();
+		// Mettre en cache avec TTL de 10 minutes (600000 millisecondes = 600 secondes)
+		await cache.set('devices', freshDevices, 600000);
+		
+		// Invalider les devices individuels en cache pour garantir la cohérence
+		if (devices && devices.length) {
+			for (const dev of devices) {
+				await cache.del(`device_${dev.getId()}`);
+			}
+		}
+		
+		return freshDevices;
 	} else {
 		logger.debug("[daikin.ts] => Cache valide")
 	}
-	return devices
+	return devices;
 }
 
 export {

--- a/src/modules/gateway/BRP069C41.ts
+++ b/src/modules/gateway/BRP069C41.ts
@@ -350,7 +350,7 @@ export class BRP069C41 implements ClassModule{
 		this._fanFixed = value;
 	}
 	set fanCurrentMode(value: string) {
-		this.fanCurrentMode = value;
+		this._fanCurrentMode = value;
 	}
 	set device(value: DevicesInformation) {
 		this._device = value;

--- a/src/modules/gateway/BRP069C4x.ts
+++ b/src/modules/gateway/BRP069C4x.ts
@@ -508,7 +508,7 @@ export class BRP069C4x implements ClassModule {
         this._fanFixed = value;
     }
     set fanCurrentMode(value: string) {
-        this.fanCurrentMode = value;
+        this._fanCurrentMode = value;
     }
     set device(value: DevicesInformation) {
         this._device = value;

--- a/src/modules/gateway/BRP069C8x.ts
+++ b/src/modules/gateway/BRP069C8x.ts
@@ -348,7 +348,7 @@ export class BRP069C8x implements ClassModule{
 		this._fanFixed = value;
 	}
 	set fanCurrentMode(value: string) {
-		this.fanCurrentMode = value;
+		this._fanCurrentMode = value;
 	}
 	set device(value: DevicesInformation) {
 		this._device = value;

--- a/src/modules/gateway/BaseModules.ts
+++ b/src/modules/gateway/BaseModules.ts
@@ -32,7 +32,7 @@ function convertDaikinDevice(device: any, gatewayClass: Gateways) {
 		let daikinValue;
 
 		try {
-			if (value.multiple == undefined && value.multiple !== true) {
+			if (value.multiple !== true) {
 				if (value.dataPointPath !== undefined) {
 					if (value.dataPoint == "consumptionData") {
 						logger.debug("[BaseModules.ts] => Récupération consommation avec dataPointPath")
@@ -45,7 +45,7 @@ function convertDaikinDevice(device: any, gatewayClass: Gateways) {
 				}
 				else daikinValue = device.getData(value.managementPoint, value.dataPoint).value
 
-			} else if (value.multiple == true) {
+			} else if (value.multiple === true) {
 				let multipleValue;
 
 				if (value.multipleValue.dataPointPath !== undefined) multipleValue = device.getData(value.multipleValue.managementPoint, value.multipleValue.dataPoint, value.multipleValue.dataPointPath).value
@@ -108,13 +108,13 @@ async function updateDaikinDevice(device: DaikinCloudDevice, gatewayClass: Gatew
 		const [key, value] = entry;
 
 		try {
-			if (value.multiple == undefined && value.multiple !== true) {
+			if (value.multiple !== true) {
 				if (value.dataPointPath !== undefined) {
 					validateDataPath(device, value, value.dataPointPath, gatewayClass[key])
 				} else {
 					validateData(device, value, gatewayClass[key])
 				}
-			} else if (value.multiple == true) {
+			} else if (value.multiple === true) {
 				let multipleValue: any;
 				if (value.multipleValue.dataPointPath !== undefined) multipleValue = device.getData(value.multipleValue.managementPoint, value.multipleValue.dataPoint, value.multipleValue.dataPointPath).value
 				else multipleValue = device.getData(value.multipleValue.managementPoint, value.multipleValue.dataPoint, null).value
@@ -137,10 +137,15 @@ async function validateData(device: DaikinCloudDevice, def: ModulePropertyMetada
 	if (!data.isOK) return;
 
 	if (params.value == data.value) return;
-	const deviceD = global.cache[device.getId()]
+	const deviceD = await cache.get(`device_${device.getId()}`) as DaikinCloudDevice | undefined;
+	
+	if (!deviceD) {
+		logger.error(`[BaseModules.ts] => Device ${device.getId()} not found in cache`);
+		return;
+	}
 
 	logger.debug('[BaseModules.ts] => Send Request to cloud : Action | '+ value)
-	await deviceD.setData(def.managementPoint, def.dataPoint, data.value);
+	await deviceD.setData(def.managementPoint, def.dataPoint, null, data.value);
 	await cache.set('needRefresh', Math.floor(Date.now() / 1000))
 }
 
@@ -151,7 +156,12 @@ async function validateDataPath(device: DaikinCloudDevice, def: ModulePropertyMe
 	if (!data.isOK) return;
 
 	if (params.value == data.value) return;
-	const deviceD = global.cache[device.getId()]
+	const deviceD = await cache.get(`device_${device.getId()}`) as DaikinCloudDevice | undefined;
+	
+	if (!deviceD) {
+		logger.error(`[BaseModules.ts] => Device ${device.getId()} not found in cache`);
+		return;
+	}
 
 	logger.debug('[BaseModules.ts] => Send Request to cloud : Action | '+ value)
 	await deviceD.setData(def.managementPoint, def.dataPoint, dataPointPath, data.value)

--- a/src/modules/mqtt.ts
+++ b/src/modules/mqtt.ts
@@ -23,17 +23,29 @@ async function loadMQTTClient() {
 	global.mqttClient = connect(mqttHost, options);
 }
 
-async function publishToMQTT(topic: string, data: string) {
-	if (await cache.get(topic) == data) return;
-	await cache.set(topic, data);
+async function publishToMQTT(topic: string, data: string): Promise<void> {
+	try {
+		const cachedData = await cache.get(topic);
+		if (cachedData === data) return;
+		
+		await cache.set(topic, data);
 
-	mqttClient.publish(config.mqtt.topic + "/" + topic, data, {qos: 0, retain: true}, (error) => {
-		logger.debug("[mqtt.ts] => Send Data to MQTT : " + topic)
-		if (error) {
-			logger.error("[mqtt.ts] => ")
-			logger.error(error)
-		}
-	})
+		return new Promise<void>((resolve, reject) => {
+			const fullTopic = config.mqtt.topic + "/" + topic;
+			mqttClient.publish(fullTopic, data, {qos: 0, retain: true}, (error) => {
+				if (error) {
+					logger.error(`[mqtt.ts] => Error publishing to ${fullTopic}: ${error}`);
+					reject(error);
+				} else {
+					logger.debug(`[mqtt.ts] => Send Data to MQTT : ${topic}`);
+					resolve();
+				}
+			});
+		});
+	} catch (error) {
+		logger.error(`[mqtt.ts] => Error in publishToMQTT for topic ${topic}: ${error}`);
+		throw error;
+	}
 }
 
 async function publishConfig(key: string, value: any) {


### PR DESCRIPTION
…ve MQTT publishing with error handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances logging and error handling, adds device-level caching with TTL and cache coherence, hardens MQTT publishing, and fixes fanCurrentMode setters across gateways.
> 
> - **Runtime / Main (`src/main.ts`)**
>   - Replace `console.*` with `logger.*`; improve token/timeout error handling and messages; publish `authorization_timeout` and exit on timeout.
> - **Daikin API (`src/modules/daikin.ts`)**
>   - Make `authorization_request` async with guarded `publishConfig` calls.
>   - On startup, handle no-device case and log device count.
>   - Message handling: wrap in try/catch, safe JSON parsing, prefer cached devices, handle refresh command.
>   - Cache devices individually (`device_<id>`) with 10m TTL when publishing; add stricter refresh timing checks.
>   - `getDevices`: add 10m TTL cache for `devices` and invalidate per-device caches on refresh.
> - **Gateway models**
>   - Fix `fanCurrentMode` setter to assign backing field in `BRP069C41`, `BRP069C4x`, `BRP069C8x`.
> - **Base modules (`src/modules/gateway/BaseModules.ts`)**
>   - Simplify `multiple` checks.
>   - Use per-device cache to apply updates; log when missing; adjust `setData` call; stricter type checks.
> - **MQTT (`src/modules/mqtt.ts`)**
>   - Refactor `publishToMQTT` to Promise-based flow with cache dedupe, retained publish, and detailed error logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e83c3ef3c80b4c66e42c93515502590b6043a4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->